### PR TITLE
Logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ before_install:
 script:
     - mkdir build
     - cd build
-    - cmake .. -DCMAKE_BUILD_TYPE=Release
+    - cmake .. -DCMAKE_BUILD_TYPE=RELEASE
     - make -j4 VERBOSE=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(CheckCCompilerFlag)
 # Default to Debug configuration
 if (NOT CMAKE_BUILD_TYPE)
 	message(STATUS "CMAKE_BUILD_TYPE not set. Using debug configuration")
-	set(CMAKE_BUILD_TYPE "Debug")
+	set(CMAKE_BUILD_TYPE DEBUG)
 endif()
 
 # Use jemalloc if available
@@ -30,6 +30,10 @@ if (CMAKE_C_COMPILER_ID MATCHES "Clang")
 elseif (CMAKE_C_COMPILER_ID MATCHES "GNU")
 	set(CFLAGS ${CFLAGS} -Wall -Wextra -Wshadow)
 endif()
+
+if (CMAKE_BUILD_TYPE MATCHES DEBUG)
+	set(CFLAGS ${CFLAGS} -DDEBUG)
+endif (CMAKE_BUILD_TYPE MATCHES DEBUG)
 
 if (CMAKE_BUILD_TYPE MATCHES RELEASE)
 	message("debug mode")

--- a/client/client.c
+++ b/client/client.c
@@ -9,14 +9,11 @@
 #include <logging.h>
 
 int main() {
-
-	log_debug("Hello, main @ %016x", &main);
+	//log_debug("Hello, main @ %016x", &main);
 	log_info("2+2 = %d", 4);
 	log_warn("Danger will %s", "robinson");
 	log_error("Boom~");
 
-
-	vec3_t x = { .x = 5, .y = 6, .z = 8 };
 	sds s = sdsnew("foo");
 	printf("%s\n", s);
 	sdsfree(s);

--- a/client/client.c
+++ b/client/client.c
@@ -9,29 +9,5 @@
 #include <logging.h>
 
 int main() {
-	//log_debug("Hello, main @ %016x", &main);
-	log_info("2+2 = %d", 4);
-	log_warn("Danger will %s", "robinson");
-	log_error("Boom~");
 
-	sds s = sdsnew("foo");
-	printf("%s\n", s);
-	sdsfree(s);
-
-	kvec_t(int) array;
-	kv_init(array);
-	for (int j = 0; j < 10; ++j)
-			kv_push(int, array, j);
-	kv_destroy(array);
-
-	int arr[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-	rand_t *ctx = rand_init();
-	for (int i = 0; i < 10; ++i) {
-			printf("%d\n", arr[i]);
-	}
-
-	rand_shuffle(ctx, arr, 10);
-	for (int i = 0; i < 10; ++i) {
-			printf("%d\n", arr[i]);
-	}
 }

--- a/client/client.c
+++ b/client/client.c
@@ -6,7 +6,16 @@
 #include <rand.h>
 #include <klib/kvec.h>
 
+#include <logging.h>
+
 int main() {
+
+	log_debug("Hello, main @ %016x", &main);
+	log_info("2+2 = %d", 4);
+	log_warn("Danger will %s", "robinson");
+	log_error("Boom~");
+
+
 	vec3_t x = { .x = 5, .y = 6, .z = 8 };
 	sds s = sdsnew("foo");
 	printf("%s\n", s);

--- a/common/logging.c
+++ b/common/logging.c
@@ -1,0 +1,119 @@
+#include "logging.h"
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef enum {
+	LEVEL_DEBUG = (1 << 0),
+	LEVEL_INFO  = (1 << 1),
+	LEVEL_WARN  = (1 << 2),
+	LEVEL_ERROR = (1 << 3),
+	LEVEL_ERRNO = (1 << 4)
+} log_level_t;
+
+static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static inline void log_timestring(char *buffer, size_t length) {
+	time_t raw_time;
+	struct tm *local_time;
+
+	time(&raw_time);
+	local_time = localtime(&raw_time);
+	strftime(buffer, length, "%T", local_time);
+}
+
+static inline void log_severity(log_level_t level, char *buffer, size_t len) {
+	switch (level) {
+		case LEVEL_DEBUG:
+			strncpy(buffer, "DEBUG: ", len);
+			break;
+		case LEVEL_INFO:
+			strncpy(buffer, "INFO: ", len);
+			break;
+		case LEVEL_WARN:
+			strncpy(buffer, "WARN: ", len);
+			break;
+		case LEVEL_ERROR:
+			strncpy(buffer, "ERROR: ", len);
+			break;
+		default:
+			strncpy(buffer, "", len);
+	}
+}
+
+#ifndef DEBUG
+static void log_write(log_level_t level, const char *fmt, va_list values)
+#else
+static void log_write(const char *file, const char *function, int line,
+	log_level_t level, const char *fmt, va_list values)
+#endif
+{
+	int error_number = errno;
+
+	if (pthread_mutex_lock(&mutex) < 0)
+		perror("pthread_mutex_lock");
+
+	FILE *stream = stdout;
+	if (level & LEVEL_WARN || level & LEVEL_ERROR)
+		stream = stderr;
+
+	char *message = 0;
+	if (vasprintf(&message, fmt, values) < 0)
+		perror("sprintf failed");
+
+	char timestamp[40] = {0};
+	log_timestring(timestamp, sizeof(timestamp) - 1);
+
+	char *error = "";
+	if (level & LEVEL_ERRNO) {
+		char buffer[128] = {0};
+		error = strerror_r(error_number, buffer, sizeof(buffer) - 1);
+	}
+
+	char severity[16];
+	log_severity(level, severity, sizeof(severity) - 1);
+
+	fprintf(stream, "[%s] %s%s %s\n", timestamp, severity, message, error);
+
+	if (pthread_mutex_unlock(&mutex) < 0)
+		perror("pthread_mutex_unlock");
+
+	free(message);
+}
+
+#ifndef DEBUG
+#define CREATE_FUNCTION(function, level)															\
+	void log_##function(const char *fmt, ...)  {													\
+		va_list values;																				\
+		va_start(values, fmt);																		\
+		log_write(level, fmt, values);																\
+		va_end(values);																				\
+		if ((level) & LEVEL_ERROR) exit(1);															\
+	}
+#else
+#define CREATE_FUNCTION(function, level)															\
+	void log_##function##_debug(const char *file, const char *func, int line,						\
+								const char *fmt, ...) {												\
+		va_list values;																				\
+		va_start(values, fmt);																		\
+		log_write(file, func, line, level, fmt, values);											\
+		va_end(values);																				\
+		if ((level) & LEVEL_ERROR) abort();															\
+	}
+
+CREATE_FUNCTION(debug, LEVEL_DEBUG)
+#endif
+
+CREATE_FUNCTION(info, LEVEL_INFO)
+CREATE_FUNCTION(warn, LEVEL_WARN)
+CREATE_FUNCTION(pwarn, LEVEL_WARN | LEVEL_ERRNO)
+CREATE_FUNCTION(error, LEVEL_ERROR)
+CREATE_FUNCTION(perror, LEVEL_ERROR | LEVEL_ERRNO)
+
+#undef CREATE_FUNCTION

--- a/common/logging.c
+++ b/common/logging.c
@@ -50,8 +50,7 @@ static void log_write(const char *file, const char *function, int line,
 		stream = stderr;
 
 	// Mutex lock required for localtime & strerror
-	if (pthread_mutex_lock(&mutex) < 0)
-		perror("pthread_mutex_lock");
+	pthread_mutex_lock(&mutex);
 
 	// Get time in HH:MM:SS format
 	time(&raw_time);
@@ -72,9 +71,7 @@ static void log_write(const char *file, const char *function, int line,
 	message = sdscat(message, "\n");
 	fwrite(message, sizeof(char), sdslen(message), stream);
 
-	if (pthread_mutex_unlock(&mutex) < 0)
-		perror("pthread_mutex_unlock");
-
+	pthread_mutex_unlock(&mutex);
 	sdsfree(message);
 }
 

--- a/common/logging.c
+++ b/common/logging.c
@@ -78,9 +78,11 @@ static void log_write(const char *file, const char *function, int line,
 
 	char severity[16];
 	log_severity(level, severity, sizeof(severity) - 1);
-
+#ifndef DEBUG
 	fprintf(stream, "[%s] %s%s %s\n", timestamp, severity, message, error);
-
+#else
+	fprintf(stream, "[%s] %s:%s:%d %s%s %s\n", timestamp, file, function, line, severity, message, error);
+#endif
 	if (pthread_mutex_unlock(&mutex) < 0)
 		perror("pthread_mutex_unlock");
 

--- a/common/logging.h
+++ b/common/logging.h
@@ -6,10 +6,9 @@
 							__attribute__((format(printf, 1, 2)))									\
 							__VA_ARGS__;
 
-#define log_debug(fmt, ...) 0
+#define log_debug(fmt, ...)
 
 #else
-
 #define CREATE_LOG_PROTOTYPE(level_, ...)															\
 	void log_##level_##_debug(const char *file, const char *fun, int line, const char *fmt, ...)	\
 							__attribute__((format(printf, 4, 5)))									\
@@ -32,9 +31,9 @@ CREATE_LOG_PROTOTYPE(debug)
 
 #endif
 
-CREATE_LOG_PROTOTYPE(info, __attribute__((unused)))
-CREATE_LOG_PROTOTYPE(warn, __attribute__((unused)))
-CREATE_LOG_PROTOTYPE(pwarn, __attribute__((unused)))
+CREATE_LOG_PROTOTYPE(info, __attribute__(()))
+CREATE_LOG_PROTOTYPE(warn, __attribute__(()))
+CREATE_LOG_PROTOTYPE(pwarn, __attribute__(()))
 CREATE_LOG_PROTOTYPE(error, __attribute__((noreturn)))
 CREATE_LOG_PROTOTYPE(perror, __attribute__((noreturn)))
 

--- a/common/logging.h
+++ b/common/logging.h
@@ -1,5 +1,11 @@
 #pragma once
 
+/**
+ * Write log entry to the appropriate stream based on severity
+ *
+ * @fmt The printf style format string for the log message
+ * @... variadic printf arguments
+ */
 #ifndef DEBUG
 #define CREATE_LOG_PROTOTYPE(level_, ...)															\
 	void log_##level_(const char *fmt, ...)															\
@@ -9,6 +15,8 @@
 #define log_debug(fmt, ...)
 
 #else
+
+// For debug configuration, also include File, Function, and Line number information
 #define CREATE_LOG_PROTOTYPE(level_, ...)															\
 	void log_##level_##_debug(const char *file, const char *fun, int line, const char *fmt, ...)	\
 							__attribute__((format(printf, 4, 5)))									\
@@ -27,13 +35,16 @@
 #define log_perror(fmt, ...)																		\
 	log_perror_debug(__FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
 
-CREATE_LOG_PROTOTYPE(debug)
+CREATE_LOG_PROTOTYPE(debug, __attribute__(()))
 
 #endif
 
+// Define the prototype for each logging level
 CREATE_LOG_PROTOTYPE(info, __attribute__(()))
 CREATE_LOG_PROTOTYPE(warn, __attribute__(()))
 CREATE_LOG_PROTOTYPE(pwarn, __attribute__(()))
+
+// Error severity causes exit(1) normally, or abort() in DEBUG
 CREATE_LOG_PROTOTYPE(error, __attribute__((noreturn)))
 CREATE_LOG_PROTOTYPE(perror, __attribute__((noreturn)))
 

--- a/common/logging.h
+++ b/common/logging.h
@@ -6,27 +6,30 @@
 							__attribute__((format(printf, 1, 2)))									\
 							__VA_ARGS__;
 
-#define log_debug(fmt, ...)
+#define log_debug(fmt, ...) 0
+
 #else
+
 #define CREATE_LOG_PROTOTYPE(level_, ...)															\
 	void log_##level_##_debug(const char *file, const char *fun, int line, const char *fmt, ...)	\
 							__attribute__((format(printf, 4, 5)))									\
-							__VA_ARGS__
+							__VA_ARGS__;
 
 #define log_debug(fmt, ...)																			\
-	log_debug_debug(__FILE__, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__)
+	log_debug_debug(__FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
 #define log_info(fmt, ...)																			\
-	log_info_debug(__FILE__, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__)
-#define log_pwarn(fmt, ...)																			\
-	log_warn_debug(__FILE__, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__)
-#define log_perror(fmt, ...)																		\
-	log_pwarn_debug(__FILE__, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__)
+	log_info_debug(__FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
+#define log_warn(fmt, ...)																			\
+	log_warn_debug(__FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
+#define log_pwarn(fmt, ...)																		    \
+	log_pwarn_debug(__FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
 #define log_error(fmt, ...)																			\
-	log_error_debug(__FILE__, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__)
+	log_error_debug(__FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
 #define log_perror(fmt, ...)																		\
-	log_perror_debug(__FILE__, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__)
+	log_perror_debug(__FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
 
 CREATE_LOG_PROTOTYPE(debug)
+
 #endif
 
 CREATE_LOG_PROTOTYPE(info, __attribute__((unused)))

--- a/common/logging.h
+++ b/common/logging.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#ifndef DEBUG
+#define CREATE_LOG_PROTOTYPE(level_, ...)															\
+	void log_##level_(const char *fmt, ...)															\
+							__attribute__((format(printf, 1, 2)))									\
+							__VA_ARGS__;
+
+#define log_debug(fmt, ...)
+#else
+#define CREATE_LOG_PROTOTYPE(level_, ...)															\
+	void log_##level_##_debug(const char *file, const char *fun, int line, const char *fmt, ...)	\
+							__attribute__((format(printf, 4, 5)))									\
+							__VA_ARGS__
+
+#define log_debug(fmt, ...)																			\
+	log_debug_debug(__FILE__, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__)
+#define log_info(fmt, ...)																			\
+	log_info_debug(__FILE__, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__)
+#define log_pwarn(fmt, ...)																			\
+	log_warn_debug(__FILE__, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__)
+#define log_perror(fmt, ...)																		\
+	log_pwarn_debug(__FILE__, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__)
+#define log_error(fmt, ...)																			\
+	log_error_debug(__FILE__, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__)
+#define log_perror(fmt, ...)																		\
+	log_perror_debug(__FILE__, __FUNCTION__, __LINE__, fmt, ##__VA_ARGS__)
+
+CREATE_LOG_PROTOTYPE(debug)
+#endif
+
+CREATE_LOG_PROTOTYPE(info, __attribute__((unused)))
+CREATE_LOG_PROTOTYPE(warn, __attribute__((unused)))
+CREATE_LOG_PROTOTYPE(pwarn, __attribute__((unused)))
+CREATE_LOG_PROTOTYPE(error, __attribute__((noreturn)))
+CREATE_LOG_PROTOTYPE(perror, __attribute__((noreturn)))
+
+#undef CREATE_LOG_PROTOTYPE


### PR DESCRIPTION
**Important Note**
This library should be the ONLY library using stderror or perror. Given that constraint, we don't need to worry about stderror not being thread safe (it's handled by the mutex).

**Important Note**
There's a potential race condition here due to localtime() being used. We can't give logging ownership over time like we did for stderror. Instead, we should probably move time functions to another library which can claim ownership and do its own mutex locking. Created #13 

**Important Note**
malloc's aren't checked in this library. That's intentional and references #14

No safety checks on pthread locking because even upon mutex failure, the log will still write correctly in at least one thread (and other threads can have undefined messages for timestamp, perror). Frankly mutex lock failing is something I don't want to worry about in a game.

Main cleaned out - we should stop using it as a testbed from now on (or at least stop committing stuff to main that was used for testing).

DEBUG/Release configurations tested on Clang 3.8.0, GCC 5.4.0, GCC 6.2.0
All log_$xx messages appear to be working as intended.

