### PR TITLE
Allocation Wrapper. Closes #14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ game
 
 [Bb]in/
 [Bb]uild/
+config.h

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
     - if [ "$CC" = "gcc" ]; then sudo apt-get install -qq gcc-5; fi
     - sudo ln -s $(which gcc-5) /usr/local/bin/gcc
     - sudo apt-get install -qq libsdl2-dev
+    - sudo apt-get install -qq libjemalloc-dev
 
 script:
     - mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CFLAGS -std=c11 -pipe -ffast-math -pedantic)
 
 # Compiler specific flags
 if (CMAKE_C_COMPILER_ID MATCHES "Clang")
-	set(CFLAGS ${CFLAGS} -Weverything -Wno-documentation-unknown-command)
+	set(CFLAGS ${CFLAGS} "-Weverything -Wno-documentation-unknown-command")
 elseif (CMAKE_C_COMPILER_ID MATCHES "GNU")
 	set(CFLAGS ${CFLAGS} -Wall -Wextra -Wshadow)
 endif()

--- a/client/client.c
+++ b/client/client.c
@@ -6,8 +6,20 @@
 #include <rand.h>
 #include <klib/kvec.h>
 
+#include <mem.h>
 #include <logging.h>
 
-int main() {
 
+int main() {
+	void* m_test = malloc(1024*64);
+	void* c_test = calloc(0x42, 1024*64);
+	void* r_test = realloc(m_test, 1024*32);
+
+	log_debug("Addrs: %p, %p, %p", m_test, c_test, r_test);
+
+
+	free(m_test);
+	free(c_test);
+	free(r_test);
+	return 0;
 }

--- a/client/client.c
+++ b/client/client.c
@@ -11,15 +11,5 @@
 
 
 int main() {
-	void* m_test = malloc(1024*64);
-	void* c_test = calloc(0x42, 1024*64);
-	void* r_test = realloc(m_test, 1024*32);
 
-	log_debug("Addrs: %p, %p, %p", m_test, c_test, r_test);
-
-
-	free(m_test);
-	free(c_test);
-	free(r_test);
-	return 0;
 }

--- a/common/config.h
+++ b/common/config.h
@@ -1,0 +1,5 @@
+#pragma once
+
+/* #undef USE_JEMALLOC */
+
+#define VERSION "daf3a94-dirty"

--- a/common/config.h
+++ b/common/config.h
@@ -1,5 +1,0 @@
-#pragma once
-
-/* #undef USE_JEMALLOC */
-
-#define VERSION "daf3a94-dirty"

--- a/common/mem.c
+++ b/common/mem.c
@@ -1,0 +1,31 @@
+#include <jemalloc/jemalloc.h>
+
+#define __MEM_W
+#include "mem.h"
+#include "logging.h"
+
+
+#define _ALLOC_WRAP(method, ...)						\
+	log_debug("Allocation Wrapper for '%s'", #method);	\
+	void* alloc = method(__VA_ARGS__); 					\
+	if(alloc == NULL) {									\
+		log_error("'%s' failed to allocate!", #method);	\
+	}													\
+	return alloc;										\
+
+void* _malloc_exit(size_t size) {
+	_ALLOC_WRAP(malloc, size);
+}
+
+void* _calloc_exit(size_t number, size_t size) {
+	_ALLOC_WRAP(calloc, number, size);
+}
+
+void* _realloc_exit(void* ptr, size_t size) {
+	_ALLOC_WRAP(realloc, ptr, size);
+}
+
+void* _aln_alloc(size_t alignment, size_t size) {
+	_ALLOC_WRAP(aligned_alloc, alignment, size);
+}
+

--- a/common/mem.c
+++ b/common/mem.c
@@ -4,9 +4,7 @@
 #include "mem.h"
 #include "logging.h"
 
-
 #define _ALLOC_WRAP(method, ...)						\
-	log_debug("Allocation Wrapper for '%s'", #method);	\
 	void* alloc = method(__VA_ARGS__); 					\
 	if(alloc == NULL) {									\
 		log_error("'%s' failed to allocate!", #method);	\

--- a/common/mem.h
+++ b/common/mem.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <stddef.h>
+
+#ifndef __MEM_W
+#define malloc  _malloc_exit
+#define calloc  _calloc_exit
+#define realloc _realloc_exit
+#define aligned_alloc _aln_alloc
+#endif
+
+void* _malloc_exit(size_t size);
+void* _calloc_exit(size_t number, size_t size);
+void* _realloc_exit(void* ptr, size_t size);
+void* _aln_alloc(size_t alignment, size_t size);


### PR DESCRIPTION
This adds a wrapper to `malloc`, `calloc`, `realloc`, and `aligned_alloc` to exit when there is an allocation failure.